### PR TITLE
feat(transactions): add TransactionActions component with test route

### DIFF
--- a/app/_components/TransactionActions.tsx
+++ b/app/_components/TransactionActions.tsx
@@ -1,0 +1,41 @@
+import { Plus } from "lucide-react";
+import Image from "next/image";
+import externalLinkIcon from "@/public/images/external-link.svg";
+
+interface TransactionActionsProps {
+  addRoute?: string;
+  viewRoute?: string;
+}
+
+export default function TransactionActions({
+  addRoute = "/transaction/add",
+  viewRoute = "/transaction",
+}: TransactionActionsProps) {
+  return (
+    <div className="ml-[-20px] w-[330px] rounded-[12px] bg-[#242424] px-[30px] py-[35px]">
+      <div className="flex items-center justify-between gap-[15px]">
+        <h2 className="text-base font-semibold text-white">Transações</h2>
+        <div className="flex gap-2">
+          <a
+            href={addRoute}
+            className="flex h-[30.29px] transform items-center gap-[3.74px] rounded-[5px] bg-neutral-700 px-[10px] text-xs text-white transition-transform hover:scale-105 hover:bg-neutral-600"
+          >
+            <Plus size={14} />
+            Adicionar
+          </a>
+          <a
+            href={viewRoute}
+            className="flex h-[30.29px] transform items-center justify-center rounded-[5px] bg-neutral-700 px-[10px] text-xs text-white transition-transform hover:scale-105 hover:bg-neutral-600"
+          >
+            <Image
+              src={externalLinkIcon}
+              alt="Visualizar Transações"
+              width={16}
+              height={16}
+            />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/transaction/page.tsx
+++ b/app/transaction/page.tsx
@@ -1,0 +1,10 @@
+import TransactionActions from "../_components/TransactionActions";
+
+export default function TransactionPage() {
+  return (
+    <div className="p-6">
+      <TransactionActions />
+      {/* Aqui você pode colocar o restante da sua página, tipo lista de transações etc */}
+    </div>
+  );
+}

--- a/public/images/external-link.svg
+++ b/public/images/external-link.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.6525 8.65062V12.4982C11.6525 12.8384 11.5173 13.1646 11.2768 13.4051C11.0363 13.6456 10.7101 13.7808 10.3699 13.7808H3.31598C2.97583 13.7808 2.64962 13.6456 2.40909 13.4051C2.16857 13.1646 2.03345 12.8384 2.03345 12.4982V5.44428C2.03345 5.10413 2.16857 4.77791 2.40909 4.53739C2.64962 4.29687 2.97583 4.16174 3.31598 4.16174H7.16359" stroke="white" stroke-width="1.28254" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.72864 2.23804H13.5762V6.08564" stroke="white" stroke-width="1.28254" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.52234 9.29198L13.5763 2.23804" stroke="white" stroke-width="1.28254" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Descrição
- Adiciona componente `TransactionActions` conforme layout
- Cria rota `/transaction` para testes
- Inclui ícone SVG

Screenshot 
![image](https://github.com/user-attachments/assets/dce45e43-59e5-4b5b-9934-be47158aca87)


Testes
- [x] Testado localmente
- [x] Visualização confere com o design
