### PR TITLE
feat: add SelectTransactionType component

### DIFF
--- a/app/_components/SelectTransactionType.tsx
+++ b/app/_components/SelectTransactionType.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import {
+  TransactionType,
+  TransactionTypeConfig,
+} from "../_types/transactionType";
+
+const SelectTransactionType = () => {
+  const [selectedType, setSelectedType] = useState<TransactionType>(
+    TransactionType.EARNING,
+  );
+
+  const { color: earningColor, label: earningLabel } =
+    TransactionTypeConfig[TransactionType.EARNING];
+  const { color: expenseColor, label: expenseLabel } =
+    TransactionTypeConfig[TransactionType.EXPENSE];
+  const { color: investmentColor, label: investmentLabel } =
+    TransactionTypeConfig[TransactionType.INVESTMENT];
+
+  return (
+    <div className="flex w-full items-center justify-center gap-3">
+      <button
+        onClick={() => setSelectedType(TransactionType.EARNING)}
+        className={"h-16 w-28 truncate rounded-2xl border p-5 font-semibold"}
+        style={
+          selectedType === TransactionType.EARNING
+            ? {
+                borderColor: earningColor,
+                color: earningColor,
+              }
+            : {}
+        }
+      >
+        {earningLabel}
+      </button>
+      <button
+        onClick={() => setSelectedType(TransactionType.EXPENSE)}
+        className={"h-16 w-28 truncate rounded-2xl border p-5 font-semibold"}
+        style={
+          selectedType === TransactionType.EXPENSE
+            ? {
+                borderColor: expenseColor,
+                color: expenseColor,
+              }
+            : {}
+        }
+      >
+        {expenseLabel}
+      </button>
+      <button
+        onClick={() => setSelectedType(TransactionType.INVESTMENT)}
+        className={"h-16 w-28 truncate rounded-2xl border p-5 font-semibold"}
+        style={
+          selectedType === TransactionType.INVESTMENT
+            ? {
+                borderColor: investmentColor,
+                color: investmentColor,
+              }
+            : {}
+        }
+      >
+        {investmentLabel}
+      </button>
+    </div>
+  );
+};
+
+export default SelectTransactionType;


### PR DESCRIPTION
![Screenshot 2025-05-07 224749](https://github.com/user-attachments/assets/b756cc8a-59ee-4767-845a-6fbcec01f9dd)
![Screenshot 2025-05-07 225419](https://github.com/user-attachments/assets/bbc2b083-afb7-4dfa-8308-c3b343f9da66)

Durante a implementação das cores por tipo de transação, percebi que o Tailwind não reconhece classes geradas dinamicamente com variáveis (como text-[${color}]), já que ele só compila classes conhecidas em build time.

Para resolver isso, apliquei as cores usando style inline, usando diretamente as variáveis CSS (var(--color)). Porém a abordagem inicial era criar funções auxiliadoras como está em uma das imagens.